### PR TITLE
Fix production build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
       {
         test: /\.tsx?$/,
         use: isProduction
-          ? 'awesome-typescript-loader?module=es6'
+          ? 'awesome-typescript-loader?module=es6&useBabel=true'
           : [
             'react-hot-loader/webpack',
             'awesome-typescript-loader'


### PR DESCRIPTION
It turned out that "npm run build" fails with reason like this:

```
ERROR in bundle.js from UglifyJs
Unexpected token: name (FileIsUploaded) [bundle.js:9781,6]

```
The root cause is that UglifyJs can't parse ES6 and JSX syntax. So we have to babel the sources first. 